### PR TITLE
Port from `syn` -> `venial`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,4 +114,14 @@ mod tests {
             ControlFlow::Break(y.clone())?;
         }
     }
+
+    struct MyStruct(u32);
+
+    impl core::convert::TryFrom<&str> for MyStruct {
+        type Error = core::num::ParseIntError;
+        #[tryvial]
+        fn try_from(value: &str) -> Result<Self, Self::Error> {
+            Self(value.parse()?)
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ mod tests {
     }
 
     #[tryvial]
-    pub fn generic_fn<T, U: Clone>(x: T, y: &U) -> ControlFlow<U>
+    unsafe fn generic_fn<T, U: Clone>(x: T, y: &U) -> ControlFlow<U>
     where
         T: PartialEq<U>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,12 @@ mod tests {
     }
 
     #[tryvial]
-    pub fn generic_fn<T: PartialEq<U>, U>(x: T, y: U) -> ControlFlow<U> {
-        if x == y {
-            ControlFlow::Break(y)?;
+    pub fn generic_fn<T, U: Clone>(x: T, y: &U) -> ControlFlow<U>
+    where
+        T: PartialEq<U>,
+    {
+        if x == *y {
+            ControlFlow::Break(y.clone())?;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,4 +104,11 @@ mod tests {
     pub fn with_doc_comments() -> ControlFlow<usize> {
         ControlFlow::Break(11)?;
     }
+
+    #[tryvial]
+    pub fn generic_fn<T: PartialEq<U>, U>(x: T, y: U) -> ControlFlow<U> {
+        if x == y {
+            ControlFlow::Break(y)?;
+        }
+    }
 }

--- a/tryvial-proc/Cargo.toml
+++ b/tryvial-proc/Cargo.toml
@@ -17,4 +17,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["full"] }
+venial = "0.5.0"

--- a/tryvial-proc/src/lib.rs
+++ b/tryvial-proc/src/lib.rs
@@ -56,13 +56,11 @@ fn impl_tryvial(input: TokenStream2) -> Result<TokenStream2, Error> {
         body,
     } = match decl {
         Declaration::Function(item) => item,
-        _ => Err(Error::new(
-            "attribute `#[tryvial]` is supported only on `fn` items",
-        ))?,
+        _ => Err(Error::new("`#[tryvial]` is supported only on `fn` items"))?,
     };
 
     let body = body.ok_or(Error::new(
-        "attribute `#[tryvial]` can only be used on functions with a body",
+        "`#[tryvial]` can only be used on functions with a body",
     ))?;
 
     let return_ty = return_ty.map_or_else(|| quote! { () }, |ty| quote! { #ty });

--- a/tryvial-proc/src/lib.rs
+++ b/tryvial-proc/src/lib.rs
@@ -39,7 +39,7 @@ pub fn tryvial(_attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn impl_tryvial(input: TokenStream2) -> Result<TokenStream2, Error> {
-    let decl = venial::parse_declaration(input.into())?;
+    let decl = venial::parse_declaration(input)?;
     let Function {
         attributes,
         vis_marker,

--- a/tryvial-proc/src/lib.rs
+++ b/tryvial-proc/src/lib.rs
@@ -1,7 +1,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::ItemFn;
+use venial::{Declaration, Error, Function};
 
 /// An attribute macro that performs "Ok-wrapping" on the return value of a `fn` item.
 /// This is compatible with [`Result`], [`Option`], [`ControlFlow`], and any type that
@@ -33,22 +33,46 @@ use syn::ItemFn;
 /// [`ControlFlow`]: core::ops::ControlFlow
 #[proc_macro_attribute]
 pub fn tryvial(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let item = syn::parse_macro_input!(item as ItemFn);
-    impl_tryvial(item).into()
+    impl_tryvial(item.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
 }
 
-fn impl_tryvial(item: ItemFn) -> TokenStream2 {
-    let ItemFn {
-        attrs,
-        vis,
-        sig,
-        block,
-    } = item;
+fn impl_tryvial(input: TokenStream2) -> Result<TokenStream2, Error> {
+    let decl = venial::parse_declaration(input.into())?;
+    let Function {
+        attributes,
+        vis_marker,
+        qualifiers,
+        tk_fn_keyword,
+        name,
+        generic_params,
+        tk_params_parens: _,
+        params,
+        where_clause,
+        tk_return_arrow: _,
+        return_ty,
+        tk_semicolon: _,
+        body,
+    } = match decl {
+        Declaration::Function(item) => item,
+        _ => Err(Error::new(
+            "attribute `#[tryvial]` is supported only on `fn` items",
+        ))?,
+    };
 
-    quote! {
-        #(#attrs)*
-        #vis #sig {
-            ::core::iter::empty().try_fold(#block, |_, __x: ::core::convert::Infallible| match __x {})
+    let body = body.ok_or(Error::new(
+        "attribute `#[tryvial]` can only be used on functions with a body",
+    ))?;
+
+    let return_ty = return_ty.map_or_else(|| quote! { () }, |ty| quote! { #ty });
+
+    Ok(quote! {
+        #(#attributes)*
+        #vis_marker #qualifiers #tk_fn_keyword #name #generic_params ( #params ) -> #return_ty
+        #where_clause
+        {
+            ::core::iter::empty().try_fold(#body, |_, __x: ::core::convert::Infallible| match __x {})
         }
-    }
+    })
 }


### PR DESCRIPTION
The use of `syn` is quite overkill for such a trivial crate. The proc macro has been changed to use `venial`, which compiles much faster. This is faster even when used in a project that already uses `syn`, as the two crates can compile in parallel.