### PR TITLE
Add `try_in_loop!()` to support bare continue and break statements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,8 @@ extern crate alloc;
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
     use super::*;
+    use alloc::vec::Vec;
     use core::ops::ControlFlow;
 
     /// This is a doc comment.
@@ -218,7 +218,8 @@ mod tests {
 
     #[test]
     fn test_continue() {
-        let results: [Result<u8, u8>; 8] = [Ok(0), Ok(1), Ok(2), Err(3), Ok(4), Ok(5), Err(6), Ok(7)];
+        let results: [Result<u8, u8>; 8] =
+            [Ok(0), Ok(1), Ok(2), Err(3), Ok(4), Ok(5), Err(6), Ok(7)];
         let mut new_results: Vec<Result<u8, u8>> = Vec::new();
         for result in results {
             let new_result = try_in_loop!(


### PR DESCRIPTION
Supports **bare** continue and break statements inside a try block. 

```rust
use tryvial::try_in_loop;
use std::num::ParseFloatError;
let string_fractions = [("1", "2"), ("15", "3"), ("0", "0"), ("ten", "five")];
let mut ratios = Vec::new();
for (numer, denom) in string_fractions {
// Note: this fails without explicitly specifying the error type.
    let ratio: Result<f64, ParseFloatError> = try_in_loop! {
    let denom = denom.parse::<f64>()?;
        if denom == 0.0 {
            continue;
        }
        let numer = numer.parse::<f64>()?;
        numer / denom
    };
    ratios.push(ratio);
}
assert!(matches!(ratios[..], [Ok(0.5), Ok(5.0), Err(_)]));
```

## Implementation
I used a closure to capture early return statements and an inner loop to capture continue and break statements, and stored the control flow as `Option<ControlFlow<()>> = None`. After capturing continue and break statements, set the control flow to `Some(ControlFlow)`, and I had to resort to unsafe code to return an uninitialized instance for the bottom type. Since the maybe uninit value is used only if we don't hit any `continue` or `break` statements, meaning the `None` value indicates the return value from the closure is valid, and we should return. Otherwise, continue or break.
## Limitations
Unlike the `try` block feature in nightly, `try_in_loop!` doesn't support continue or break with a label, or break with value. It also doesn't support returning a value for the function this caller is in. 
```rust
// Suppose the function returns `Vec<u8>` and has a `loop` labeled `'my_label` that returns `bool`
let res: Result<i32, String> = try {
    let b: i32 = a?;
    match b {
        0 => return b"hello".to_vec(),
        1 => break 'my_label true,
        2 => { counter += 1; continue },
        b => b
    }
};
```
also, `try_in_loop!` can **only** be used inside a loop because the match arms contain `continue` and `break` statements